### PR TITLE
Fix "make check-TESTS"

### DIFF
--- a/src/write_splunk_test.c
+++ b/src/write_splunk_test.c
@@ -197,14 +197,20 @@ DEF_TEST(splunk_transforms) {
     char dims_json[WS_METRIC_MAX_NAME_LEN] = {0};
 
     sstrncpy(vl.plugin, cases[i].plugin, sizeof(vl.plugin));
-    if (cases[i].plugin_instance != NULL)
+    if (cases[i].plugin_instance != NULL) {
       strncpy(vl.plugin_instance, cases[i].plugin_instance,
               sizeof(vl.plugin_instance));
-    if (cases[i].type != NULL)
+      vl.plugin_instance[sizeof(vl.plugin_instance) - 1] = '\0';
+    }
+    if (cases[i].type != NULL) {
       strncpy(vl.type, cases[i].type, sizeof(vl.type));
-    if (cases[i].type_instance != NULL)
+      vl.type[sizeof(vl.type) - 1] = '\0';
+    }
+    if (cases[i].type_instance != NULL) {
       strncpy(vl.type_instance, cases[i].type_instance,
               sizeof(vl.type_instance));
+      vl.type_instance[sizeof(vl.type_instance) - 1] = '\0';
+    }
 
     ws_transform(dims_json, metric_name, &vl, &pl_config);
     EXPECT_EQ_STR(cases[i].expected_name, metric_name);


### PR DESCRIPTION
Resolves #4

* Fix "make check-TESTS"
  - I've added a simple fix to resolve string truncation warnings and allow tests to run (warnings are blocking).
  
Tests pass now.
  
 
![Screen Shot 2021-08-19 at 5 35 31 PM](https://user-images.githubusercontent.com/83429393/130161150-a667c4e2-f4c9-40c0-a40e-6c7908b0a14c.png)


(self-reminder to get myself added to this repo)
